### PR TITLE
resolve breaking tests

### DIFF
--- a/test/bridge/SynapseBridge-test.ts
+++ b/test/bridge/SynapseBridge-test.ts
@@ -63,7 +63,7 @@ describe("SynapseBridge", function() {
                         expected = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
                         break;
                     case ChainId.BOBA:
-                        expected = "0x037527278B4ac8A4327e7015B788001c2954Cf82";
+                        expected = "0xd203De32170130082896b4111eDF825a4774c18E";
                         break;
                     default:
                         expected = "0x0000000000000000000000000000000000000000";
@@ -205,7 +205,7 @@ describe("SynapseBridge", function() {
                         tokenTo:     Tokens.USDT,
                         amountFrom:  Tokens.USDC.valueToWei("35", ChainId.BSC),
                     },
-                    notZero:   true,
+                    notZero:   false,
                     wantError: false,
                 },
                 {


### PR DESCRIPTION
```
  1) SynapseBridge
       read-only wrapper functions
         .WETH_ADDRESS
           Should return 0x037527278B4ac8A4327e7015B788001c2954Cf82 for Chain ID 288:

      AssertionError: expected '0xd203De32170130082896b4111eDF825a4774c18E' to equal '0x037527278B4ac8A4327e7015B788001c2954Cf82'
      + expected - actual

      -0xd203De32170130082896b4111eDF825a4774c18E
      +0x037527278B4ac8A4327e7015B788001c2954Cf82
      
      at /home/.../sdk/node_modules/chai-as-promised/lib/chai-as-promised.js:302:22
      at processTicksAndRejections (node:internal/process/task_queues:96:5)

  2) SynapseBridge
       read-only wrapper functions
         getEstimatedBridgeOutput
           getEstimatedBridgeOutput with params USDC on Binance Smart Chain to USDT on Boba Network should return a value greater than zero:

      AssertionError: expected false to be true
      + expected - actual

      -false
      +true
```

1) Per the new [WETH.json](https://github.com/synapsecns/synapse-contracts/blob/b3829f7c2177e9daf35d176713243acb6c43ea2b/deployments/boba/WETH.json#L2) the WETH address on Boba has changed.

2) As of writing this PR (2021-12-03) USDC transfers are not enabled on Boba.