### PR TITLE
internal/rpcprovider: implement RpcConnector class

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@ethersproject/providers": "^5.5.0",
     "@ethersproject/units": "^5.5.0",
     "@ethersproject/wallet": "^5.5.0",
+    "@web3-react/abstract-connector": "^6.0.7",
     "dotenv": "^10.0.0",
     "ethers": "^5.5.1",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dotenv": "^10.0.0",
     "ethers": "^5.5.1",
     "lodash": "^4.17.21",
+    "node-fetch": "^3.2.0",
     "utility-types": "^3.10.0"
   },
   "devDependencies": {

--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -8,8 +8,8 @@ import {
 } from "../common/utils";
 
 import type {ID} from "../internal/entity";
-import {SwapType} from "../internal/swaptype";
-import {newProviderForNetwork} from "../internal/rpcproviders";
+import {SwapType}              from "../internal/swaptype";
+import {rpcProviderForNetwork} from "../internal/rpcproviders";
 
 import type {
     GenericZapBridgeContract,
@@ -115,7 +115,7 @@ export namespace Bridge {
         private readonly bridgeConfigInstance = SynapseEntities.bridgeConfig();
         private readonly zapBridgeInstance = SynapseEntities.l1BridgeZap({
             chainId: ChainId.ETH,
-            signerOrProvider: newProviderForNetwork(ChainId.ETH),
+            signerOrProvider: rpcProviderForNetwork(ChainId.ETH),
         });
 
         readonly requiredConfirmations: number;
@@ -128,7 +128,7 @@ export namespace Bridge {
 
             this.network = network instanceof Networks.Network ? network : Networks.fromChainId(network);
             this.chainId = this.network.chainId;
-            this.provider = provider ?? newProviderForNetwork(this.chainId);
+            this.provider = provider ?? rpcProviderForNetwork(this.chainId);
 
             this.requiredConfirmations = getRequiredConfirmationsForBridge(this.network);
 
@@ -419,7 +419,7 @@ export namespace Bridge {
         private async calculateBridgeRate(args: BridgeParams): Promise<BridgeOutputEstimate> {
             let {chainIdTo, amountFrom} = args;
 
-            const toChainZapParams = {chainId: chainIdTo, signerOrProvider: newProviderForNetwork(chainIdTo)};
+            const toChainZapParams = {chainId: chainIdTo, signerOrProvider: rpcProviderForNetwork(chainIdTo)};
             const toChainZap: GenericZapBridgeContract = SynapseEntities.zapBridge(toChainZapParams);
 
             const {

--- a/src/bridge/erc20.ts
+++ b/src/bridge/erc20.ts
@@ -14,7 +14,7 @@ import {
     ERC20Contract,
 } from "../contracts";
 
-import {newProviderForNetwork} from "../internal/rpcproviders";
+import {rpcProviderForNetwork} from "../internal/rpcproviders";
 
 import {
     executePopulatedTransaction,
@@ -47,7 +47,7 @@ export namespace ERC20 {
             this.address = args.tokenAddress;
             this.chainId = args.chainId;
 
-            this.provider = newProviderForNetwork(this.chainId);
+            this.provider = rpcProviderForNetwork(this.chainId);
             this.instance = ERC20Factory.connect(this.address, this.provider);
         }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -4,5 +4,7 @@ import type {Provider} from "@ethersproject/providers";
 export type SignerOrProvider = Signer | Provider;
 
 export interface ChainIdTypeMap<T> {[chainId: number]: T}
-export type AddressMap  = ChainIdTypeMap<string>
+export type StringMap   = ChainIdTypeMap<string>
 export type DecimalsMap = ChainIdTypeMap<number>
+
+export type AddressMap  = StringMap

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,6 +1,9 @@
 import {ChainId} from "./chainid";
 import {SynapseContracts} from "./synapse_contracts";
 
+import type {JsonRpcProvider} from "@ethersproject/providers";
+import {setRpcUriForNetwork} from "../internal/rpcproviders";
+
 import type {Signer} from "@ethersproject/abstract-signer";
 
 import type {
@@ -44,3 +47,13 @@ const CHAINID_CONTRACTS_MAP: {[c: number]: SynapseContracts.SynapseContract} = {
 
 export const contractsForChainId = (chainId: number): SynapseContracts.SynapseContract => CHAINID_CONTRACTS_MAP[chainId] ?? null
 
+/**
+ * Sets the JSON-RPC URI for a given chain ID. All SDK functions which use internal, pre-initialized
+ * {@link JsonRpcProvider} instances which retrieve the {@link JsonRpcProvider} for the passed chain ID
+ * will henceforth use an instance which uses the passed URI.
+ * @param chainId
+ * @param uri
+ */
+export function setJsonRpcUriForNetwork(chainId: number, uri: string) {
+    setRpcUriForNetwork(chainId, uri);
+}

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -18,7 +18,7 @@ import {
 import type {SignerOrProvider} from "./common/types";
 import {contractAddressFor} from "./common/utils";
 import {ChainId} from "./common/chainid";
-import {newProviderForNetwork} from "./internal/rpcproviders";
+import {rpcProviderForNetwork} from "./internal/rpcproviders";
 
 
 export const newSynapseBridgeInstance = (params: {
@@ -80,12 +80,12 @@ export namespace SynapseEntities {
     }
 
     export function bridgeConfig(): BridgeConfigContract {
-        const provider = newProviderForNetwork(ChainId.ETH);
+        const provider = rpcProviderForNetwork(ChainId.ETH);
         return BridgeConfigFactory.connect(bridgeConfigAddress, provider)
     }
 
     export function poolConfig(): PoolConfigContract {
-        const provider = newProviderForNetwork(ChainId.ETH);
+        const provider = rpcProviderForNetwork(ChainId.ETH);
         return PoolConfigFactory.connect(poolConfigAddress, provider)
     }
 }

--- a/src/internal/minirpc.ts
+++ b/src/internal/minirpc.ts
@@ -1,0 +1,153 @@
+import fetch, {Response} from "node-fetch";
+
+
+export class RequestError extends Error {
+    readonly code: number;
+    readonly data: any;
+
+    constructor(message: string, code: number, data: any) {
+        super(message)
+        this.code = code
+        this.data = data
+        this.name = this.constructor.name // dafuq
+        this.message = message // dafuq message
+    }
+}
+
+interface MiniRpcRequest {
+    jsonrpc: string,
+    id:      number,
+    method:  string,
+    params:  any,
+}
+
+interface MiniRpcBatchItem {
+    request: MiniRpcRequest;
+    resolve: (value: unknown) => void;
+    reject:  (reason?: any)   => void,
+}
+
+export class MiniRpcProvider {
+    readonly isMetaMask:      boolean;
+    readonly chainId:         number;
+
+    readonly url:             string;
+    readonly host:            string;
+    readonly path:            string;
+
+    readonly batchWaitTimeMs: number;
+
+    protected nextId:         number;
+    protected batchTimeoutId: string | NodeJS.Timeout;
+    protected batch:          MiniRpcBatchItem[];
+
+    constructor(chainId: number, url: string, batchWaitTimeMs?: number) {
+        this.isMetaMask = false
+        this.nextId = 1
+        this.batchTimeoutId = null
+        this.batch = []
+
+        this.chainId = chainId
+        this.url = url
+        const parsed = new URL(url)
+        this.host = parsed.host
+        this.path = parsed.pathname
+        // how long to wait to batch calls
+        this.batchWaitTimeMs = batchWaitTimeMs ?? 50
+    }
+
+    async request(method: string|MiniRpcRequest, params: any) {
+        const _method: string = typeof method === "string" ? method : method.method;
+
+        if (_method === 'eth_chainId') {
+            return `0x${this.chainId.toString(16)}`
+        }
+
+        const promise = new Promise((resolve, reject) => {
+            this.batch.push({
+                request: {
+                    jsonrpc: '2.0',
+                    id: this.nextId++,
+                    method: _method,
+                    params
+                },
+                resolve,
+                reject
+            })
+        });
+
+        this.batchTimeoutId = this.batchTimeoutId ?? setTimeout(this.clearBatch, this.batchWaitTimeMs);
+
+        return promise
+    }
+
+    sendAsync(request: MiniRpcRequest, callback: any) {
+        this.request(request.method, request.params)
+            .then(result => callback(null, { jsonrpc: '2.0', id: request.id, result }))
+            .catch(error => callback(error, null))
+    }
+
+    async clearBatch() {
+        const batch = this.batch;
+        this.batch = [];
+        this.batchTimeoutId = null;
+
+        const rejectBatchItem = (reason: any): (item: MiniRpcBatchItem) => void =>
+            ({reject}) => reject(reason instanceof Error ? reason : new Error(reason));
+
+        let response: Response;
+        try {
+            response = await fetch(this.url, {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    accept: 'application/json'
+                },
+                body: JSON.stringify(batch.map(item => item.request))
+            });
+        } catch (error) {
+            batch.forEach(rejectBatchItem("Failed to send batch call"));
+            return
+        }
+
+        if (!response.ok) {
+            batch.forEach(rejectBatchItem(`${response.status}: ${response.statusText}`))
+            return
+        }
+
+        let json: any;
+        try {
+            json = await response.json();
+        } catch (error) {
+            batch.forEach(rejectBatchItem("Failed to parse JSON response"));
+            return
+        }
+
+        const byKey = batch.reduce((memo, current) => {
+            memo[current.request.id] = current
+            return memo
+        }, {});
+
+        try {
+            if (json?.error?.code === -32700) {
+                console.error(`${this.chainId} RPC gave invalid response`)
+                return
+            }
+
+            for (const result of json) {
+                const { resolve, reject, request: { method } } = byKey[result.id]
+
+                if (resolve && reject) {
+                    if ("error" in result) {
+                        reject(result?.error)
+                    } else if ("result" in result) {
+                        resolve(result.result)
+                    } else {
+                        reject(new RequestError(`Received unexpected JSON-RPC response to ${method} request.`, -32000, result))
+                    }
+                }
+            }
+        } catch (e) {}
+
+    }
+}

--- a/src/internal/rpcconnector.ts
+++ b/src/internal/rpcconnector.ts
@@ -19,6 +19,38 @@ export class RpcConnector {
         return this.providers[chainId]
     }
 
+    /**
+     * Returns a potentially new {@link JsonRpcProvider} instance for the given chain ID
+     * using the passed uri for the connection.
+     * If the passed uri is the same as the uri for a pre-existing JsonRpcProvider instance,
+     * said instance is returned rather than instantiating a brand new one.
+     * @param chainId
+     * @param uri
+     */
+    providerWithUri(chainId: number, uri: string): JsonRpcProvider {
+        const _existingProvider = this.providers[chainId];
+
+        if (_existingProvider?.connection.url === uri) {
+            return _existingProvider
+        }
+
+        return new JsonRpcProvider(uri)
+    }
+
+    /**
+     * Re-initializes the JsonRpcProvider instance for a given chain ID using the passed URI.
+     * This operation is permanent for the lifetime of whatever is using the RpcConnector.
+     * @param chainId
+     * @param uri
+     */
+    setProviderUri(chainId: number, uri: string) {
+        if (chainId in this.providers) {
+            delete this.providers[chainId];
+        }
+
+        this.providers[chainId] = new JsonRpcProvider(uri);
+    }
+
     supportedChainIds(): number[] {
         return Object.keys(this.urls).map(cid => Number(cid))
     }

--- a/src/internal/rpcconnector.ts
+++ b/src/internal/rpcconnector.ts
@@ -1,44 +1,44 @@
-import {ChainIdTypeMap, StringMap} from "../common/types";
-import {JsonRpcProvider} from "@ethersproject/providers";
+import type {ChainIdTypeMap, StringMap} from "../common/types";
+import {JsonRpcProvider, Provider} from "@ethersproject/providers";
 
-export class RpcConnector {
-    protected urls:      StringMap;
-    protected providers: ChainIdTypeMap<JsonRpcProvider>;
+import {MiniRpcProvider} from "./minirpc";
 
-    constructor(args: {urls: StringMap}) {
-        const {urls} = args;
+export interface ProviderConnector<T extends Provider | MiniRpcProvider> {
+    provider:          (chainId: number) => T;
+    providerWithUri:   (chainId: number, uri: string) => T;
+    setProviderUri:    (chainId: number, uri: string) => void;
+    supportedChainIds: () => number[];
+}
+
+class AbstractProviderConnector<T extends Provider> implements ProviderConnector<T> {
+    protected urls:           StringMap;
+    protected providers:      ChainIdTypeMap<T>;
+    protected newProviderFn:  (uri: string) => T;
+
+    constructor(args: {
+        urls: StringMap,
+        newProvider: (uri: string) => T
+    }) {
+        const {urls, newProvider} = args;
         this.urls = urls;
+        this.newProviderFn = newProvider;
         this.providers = Object.keys(urls).reduce((acc, chainId) => {
             const cid = Number(chainId);
-            acc[cid] = new JsonRpcProvider(urls[cid]);
+            acc[cid] = newProvider(urls[cid]);
             return acc
         }, {});
     }
 
-    provider(chainId: number): JsonRpcProvider {
+    provider(chainId: number): T {
         return this.providers[chainId]
     }
 
-    /**
-     * Returns a potentially new {@link JsonRpcProvider} instance for the given chain ID
-     * using the passed uri for the connection.
-     * If the passed uri is the same as the uri for a pre-existing JsonRpcProvider instance,
-     * said instance is returned rather than instantiating a brand new one.
-     * @param chainId
-     * @param uri
-     */
-    providerWithUri(chainId: number, uri: string): JsonRpcProvider {
-        const _existingProvider = this.providers[chainId];
-
-        if (_existingProvider?.connection.url === uri) {
-            return _existingProvider
-        }
-
-        return new JsonRpcProvider(uri)
+    providerWithUri(chainId: number, uri: string): T {
+        return this.newProviderFn(uri)
     }
 
     /**
-     * Re-initializes the JsonRpcProvider instance for a given chain ID using the passed URI.
+     * Re-initializes the Provider instance for a given chain ID using the passed URI.
      * This operation is permanent for the lifetime of whatever is using the RpcConnector.
      * @param chainId
      * @param uri
@@ -48,7 +48,76 @@ export class RpcConnector {
             delete this.providers[chainId];
         }
 
-        this.providers[chainId] = new JsonRpcProvider(uri);
+        this.providers[chainId] = this.newProviderFn(uri);
+    }
+
+    supportedChainIds(): number[] {
+        return Object.keys(this.urls).map(cid => Number(cid))
+    }
+}
+
+export class RpcConnector extends AbstractProviderConnector<JsonRpcProvider> implements ProviderConnector<JsonRpcProvider> {
+    constructor(args: {urls: StringMap}) {
+        super({
+            ...args,
+            newProvider: (uri: string) => new JsonRpcProvider(uri)
+        });
+    }
+
+    /**
+     * Returns a potentially new {@link JsonRpcProvider} instance for the given chain ID
+     * using the passed uri for the connection.
+     * If the passed uri is the same as the uri for a pre-existing JsonRpcProvider instance,
+     * said instance is returned rather than instantiating a brand new one.
+     * @param chainId
+     * @param uri
+     * @override
+     */
+    providerWithUri(chainId: number, uri: string): JsonRpcProvider {
+        const _existing = this.providers[chainId];
+        if (_existing?.connection.url === uri) {
+            return _existing
+        }
+
+        return super.providerWithUri(chainId, uri)
+    }
+}
+
+export class Web3Connector implements ProviderConnector<MiniRpcProvider> {
+    readonly urls:      StringMap;
+    readonly providers: ChainIdTypeMap<MiniRpcProvider>;
+
+    constructor(args: {urls: StringMap}) {
+        const {urls} = args;
+        this.urls = urls;
+
+        this.providers = Object.keys(urls).reduce((acc, chainId) => {
+            const cid = Number(chainId);
+            acc[cid] = new MiniRpcProvider(cid, urls[cid]);
+            return acc
+        }, {});
+    }
+
+    provider(chainId: number): MiniRpcProvider {
+        return this.providers[chainId]
+    }
+
+    providerWithUri(chainId: number, uri: string): MiniRpcProvider {
+        return new MiniRpcProvider(chainId, uri);
+    }
+
+    /**
+     * Re-initializes the Provider instance for a given chain ID using the passed URI.
+     * This operation is permanent for the lifetime of whatever is using the RpcConnector.
+     * @param chainId
+     * @param uri
+     */
+    setProviderUri(chainId: number, uri: string) {
+        if (chainId in this.providers) {
+            delete this.providers[chainId];
+        }
+
+        this.providers[chainId] = new MiniRpcProvider(chainId, uri);
     }
 
     supportedChainIds(): number[] {

--- a/src/internal/rpcconnector.ts
+++ b/src/internal/rpcconnector.ts
@@ -1,0 +1,25 @@
+import {ChainIdTypeMap, StringMap} from "../common/types";
+import {JsonRpcProvider} from "@ethersproject/providers";
+
+export class RpcConnector {
+    protected urls:      StringMap;
+    protected providers: ChainIdTypeMap<JsonRpcProvider>;
+
+    constructor(args: {urls: StringMap}) {
+        const {urls} = args;
+        this.urls = urls;
+        this.providers = Object.keys(urls).reduce((acc, chainId) => {
+            const cid = Number(chainId);
+            acc[cid] = new JsonRpcProvider(urls[cid]);
+            return acc
+        }, {});
+    }
+
+    provider(chainId: number): JsonRpcProvider {
+        return this.providers[chainId]
+    }
+
+    supportedChainIds(): number[] {
+        return Object.keys(this.urls).map(cid => Number(cid))
+    }
+}

--- a/src/internal/rpcproviders.ts
+++ b/src/internal/rpcproviders.ts
@@ -44,13 +44,13 @@ const CHAIN_RPC_URIS: StringMap = {
 
 const LOADED_CHAIN_RPC_URIS: StringMap = _.fromPairs(supportedChainIds().map(cid => [cid, rpcUriForChainId(cid)]))
 
-const PROVIDERS: RpcConnector = new RpcConnector({urls: LOADED_CHAIN_RPC_URIS});
+const RPC_CONNECTORS: RpcConnector = new RpcConnector({urls: LOADED_CHAIN_RPC_URIS});
 
 /**
  * @param chainId chain id of the network for which to return a provider
  */
 export function rpcProviderForNetwork(chainId: number): Provider {
-    return PROVIDERS.provider(chainId)
+    return RPC_CONNECTORS.provider(chainId)
 }
 
 /**
@@ -69,6 +69,10 @@ function checkEnv(chainId: number): string|undefined {
     return envKey in process.env ? process.env[envKey] : undefined
 }
 
+export function setRpcUriForNetwork(chainId: number, uri: string) {
+    RPC_CONNECTORS.setProviderUri(chainId, uri);
+}
+
 /**
  * Used solely for tests, initRpcConnectors() basically just makes sure on-import initialization
  * of Rpc connections occurs before tests run.
@@ -76,3 +80,4 @@ function checkEnv(chainId: number): string|undefined {
 export function initRpcConnectors() {
     //
 }
+

--- a/src/internal/rpcproviders.ts
+++ b/src/internal/rpcproviders.ts
@@ -4,49 +4,32 @@ import type {Provider} from "@ethersproject/providers";
 import {JsonRpcProvider} from "@ethersproject/providers";
 
 import {ChainId, supportedChainIds} from "../common/chainid";
-import type {ChainIdTypeMap} from "../common/types";
+import type {StringMap} from "../common/types";
 
-type RpcProviderMap = ChainIdTypeMap<Provider>;
+import {RpcConnector} from "./rpcconnector";
 
-const
-    ETH_RPC_URI_ENV:       string = "ETH_RPC_URI",
-    OPTIMISM_RPC_URI_ENV:  string = "OPTIMISM_RPC_URI",
-    CRONOS_RPC_URI_ENV:    string = "CRONOS_RPC_URI",
-    BSC_RPC_URI_ENV:       string = "BSC_RPC_URI",
-    POLYGON_RPC_URI_ENV:   string = "POLYGON_RPC_URI",
-    FANTOM_RPC_URI_ENV:    string = "FANTOM_RPC_URI",
-    BOBA_RPC_URI_ENV:      string = "BOBA_RPC_URI",
-    METIS_RPC_URI_ENV:     string = "METIS_RPC_URI",
-    MOONBEAM_RPC_URI_ENV:  string = "MOONBEAM_RPC_URI",
-    MOONRIVER_RPC_URI_ENV: string = "MOONRIVER_RPC_URI",
-    ARBITRUM_RPC_URI_ENV:  string = "ARBITRUM_RPC_URI",
-    AVALANCHE_RPC_URI_ENV: string = "AVALANCHE_RPC_URI",
-    AURORA_RPC_URI_ENV:    string = "AURORA_RPC_URI",
-    HARMONY_RPC_URI_ENV:   string = "HARMONY_RPC_URI";
-
-
-const ENV_KEY_MAP: ChainIdTypeMap<string> = {
-    [ChainId.ETH]:       ETH_RPC_URI_ENV,
-    [ChainId.OPTIMISM]:  OPTIMISM_RPC_URI_ENV,
-    [ChainId.CRONOS]:    CRONOS_RPC_URI_ENV,
-    [ChainId.BSC]:       BSC_RPC_URI_ENV,
-    [ChainId.POLYGON]:   POLYGON_RPC_URI_ENV,
-    [ChainId.FANTOM]:    FANTOM_RPC_URI_ENV,
-    [ChainId.BOBA]:      BOBA_RPC_URI_ENV,
-    [ChainId.METIS]:     METIS_RPC_URI_ENV,
-    [ChainId.MOONBEAM]:  MOONBEAM_RPC_URI_ENV,
-    [ChainId.MOONRIVER]: MOONRIVER_RPC_URI_ENV,
-    [ChainId.ARBITRUM]:  ARBITRUM_RPC_URI_ENV,
-    [ChainId.AVALANCHE]: AVALANCHE_RPC_URI_ENV,
-    [ChainId.AURORA]:    AURORA_RPC_URI_ENV,
-    [ChainId.HARMONY]:   HARMONY_RPC_URI_ENV,
+const ENV_KEY_MAP: StringMap = {
+    [ChainId.ETH]:       "ETH_RPC_URI",
+    [ChainId.OPTIMISM]:  "OPTIMISM_RPC_URI",
+    [ChainId.CRONOS]:    "CRONOS_RPC_URI",
+    [ChainId.BSC]:       "BSC_RPC_URI",
+    [ChainId.POLYGON]:   "POLYGON_RPC_URI",
+    [ChainId.FANTOM]:    "FANTOM_RPC_URI",
+    [ChainId.BOBA]:      "BOBA_RPC_URI",
+    [ChainId.METIS]:     "METIS_RPC_URI",
+    [ChainId.MOONBEAM]:  "MOONBEAM_RPC_URI",
+    [ChainId.MOONRIVER]: "MOONRIVER_RPC_URI",
+    [ChainId.ARBITRUM]:  "ARBITRUM_RPC_URI",
+    [ChainId.AVALANCHE]: "AVALANCHE_RPC_URI",
+    [ChainId.AURORA]:    "AURORA_RPC_URI",
+    [ChainId.HARMONY]:   "HARMONY_RPC_URI",
 }
 
-const CHAIN_RPC_URIS: ChainIdTypeMap<string> = {
+const CHAIN_RPC_URIS: StringMap = {
     [ChainId.ETH]:       "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
     [ChainId.OPTIMISM]:  "https://mainnet.optimism.io",
     [ChainId.CRONOS]:    "https://evm-cronos.crypto.org",
-    [ChainId.BSC]:       "https://bsc-dataseed1.binance.org/",
+    [ChainId.BSC]:       "https://bsc-dataseed.binance.org/",
     [ChainId.POLYGON]:   "https://polygon-rpc.com/",
     [ChainId.FANTOM]:    "https://rpc.ftm.tools/",
     [ChainId.BOBA]:      "https://replica-oolong.boba.network/",
@@ -59,11 +42,22 @@ const CHAIN_RPC_URIS: ChainIdTypeMap<string> = {
     [ChainId.HARMONY]:   "https://api.harmony.one/",
 }
 
-const PROVIDERS: RpcProviderMap = _.fromPairs(supportedChainIds().map(c => [c, new JsonRpcProvider(rpcUriForChainId(c))]));
+const LOADED_CHAIN_RPC_URIS: StringMap = _.fromPairs(supportedChainIds().map(cid => [cid, rpcUriForChainId(cid)]))
 
-export function newProviderForNetwork(chainId: number): Provider {
-    return PROVIDERS[chainId] ?? null
+const PROVIDERS: RpcConnector = new RpcConnector({urls: LOADED_CHAIN_RPC_URIS});
+
+/**
+ * @param chainId chain id of the network for which to return a provider
+ */
+export function rpcProviderForNetwork(chainId: number): Provider {
+    return PROVIDERS.provider(chainId)
 }
+
+/**
+ * @deprecated use {@link rpcProviderForNetwork}
+ * @param chainId chain id of the network for which to return a provider
+ */
+export const newProviderForNetwork = rpcProviderForNetwork
 
 export function rpcUriForChainId(chainId: number): string {
     return checkEnv(chainId) ?? CHAIN_RPC_URIS[chainId]
@@ -72,11 +66,7 @@ export function rpcUriForChainId(chainId: number): string {
 function checkEnv(chainId: number): string|undefined {
     const envKey: string = ENV_KEY_MAP[chainId];
 
-    if (envKey in process.env) {
-        return process.env[envKey]
-    }
-
-    return undefined
+    return envKey in process.env ? process.env[envKey] : undefined
 }
 
 /**

--- a/src/internal/rpcproviders.ts
+++ b/src/internal/rpcproviders.ts
@@ -1,7 +1,6 @@
 import _ from "lodash";
 
 import type {Provider} from "@ethersproject/providers";
-import {JsonRpcProvider} from "@ethersproject/providers";
 
 import {ChainId, supportedChainIds} from "../common/chainid";
 import type {StringMap} from "../common/types";

--- a/src/tokenswap.ts
+++ b/src/tokenswap.ts
@@ -10,7 +10,7 @@ import {ChainId, supportedChainIds} from "./common/chainid";
 import {Networks} from "./common/networks";
 
 import {SwapType} from "./internal/swaptype";
-import {newProviderForNetwork} from "./internal/rpcproviders";
+import {rpcProviderForNetwork} from "./internal/rpcproviders";
 
 import {PopulatedTransaction} from "@ethersproject/contracts";
 import {BigNumber, BigNumberish} from "@ethersproject/bignumber";
@@ -258,7 +258,7 @@ export namespace TokenSwap {
             lpToken            = intermediateToken(token, chainId),
             {poolAddress}      = await POOL_CONFIG_INSTANCE.getPoolConfig(lpToken.address(chainId), chainId);
 
-        return SwapFactory.connect(poolAddress, newProviderForNetwork(chainId))
+        return SwapFactory.connect(poolAddress, rpcProviderForNetwork(chainId))
     }
 
     async function swapSetup(tokenFrom: Token, tokenTo: Token, chainId: number): Promise<SwapSetup> {

--- a/test/basic/Basic-test.ts
+++ b/test/basic/Basic-test.ts
@@ -15,6 +15,7 @@ import {
     Tokens
 } from "../../src";
 
+import {JsonRpcProvider} from "@ethersproject/providers";
 
 import {setJsonRpcUriForNetwork} from "../../src/common/utils";
 import {rpcProviderForNetwork} from "../../src/internal/rpcproviders";
@@ -51,7 +52,7 @@ describe("Basic tests", function(this: Mocha.Suite) {
 
     describe("setJsonRpcUriForNetwork", function(this: Mocha.Suite) {
         function getURI(chainId: number): string {
-            return rpcProviderForNetwork(chainId).connection.url
+            return (rpcProviderForNetwork(chainId) as JsonRpcProvider).connection.url
         }
 
         interface TestCase {

--- a/test/bridge/SynapseBridge-test.ts
+++ b/test/bridge/SynapseBridge-test.ts
@@ -16,11 +16,9 @@ import {
     supportedChainIds,
 } from "../../src";
 
-import {contractAddressFor} from "../../src/common/utils";
-
 import {ERC20} from "../../src/bridge/erc20";
-
-import {newProviderForNetwork} from "../../src/internal/rpcproviders";
+import {contractAddressFor} from "../../src/common/utils";
+import {rpcProviderForNetwork} from "../../src/internal/rpcproviders";
 
 import type {Provider}    from "@ethersproject/providers";
 import {Wallet}           from "@ethersproject/wallet";
@@ -71,9 +69,9 @@ describe("SynapseBridge", function(this: Mocha.Suite) {
 
             for (const network of ALL_CHAIN_IDS) {
                 const
-                    provider          = newProviderForNetwork(network),
-                    bridgeInstance    = new Bridge.SynapseBridge({ network, provider}),
-                    testTitle: string = `Should return ${expected.toString()} on Chain ID ${network}`;
+                    testTitle: string = `Should return ${expected.toString()} on Chain ID ${network}`,
+                    provider          = rpcProviderForNetwork(network),
+                    bridgeInstance    = new Bridge.SynapseBridge({ network, provider});
 
                 it(testTitle, async function(this: Mocha.Context) {
                     this.timeout(DEFAULT_TEST_TIMEOUT);
@@ -86,7 +84,7 @@ describe("SynapseBridge", function(this: Mocha.Suite) {
         describe(".WETH_ADDRESS", function(this: Mocha.Suite) {
             for (const network of ALL_CHAIN_IDS) {
                 const
-                    provider = newProviderForNetwork(network),
+                    provider = rpcProviderForNetwork(network),
                     bridgeInstance = new Bridge.SynapseBridge({ network, provider }),
                     expected: string = ((): string => {
                         switch (network) {
@@ -131,7 +129,7 @@ describe("SynapseBridge", function(this: Mocha.Suite) {
 
             const makeTestCase = (c: number, t: Token, a: string, n: BigNumberish): testCase => {
                 return {
-                    provider:   newProviderForNetwork(c),
+                    provider:   rpcProviderForNetwork(c),
                     chainId:    c,
                     token:      t,
                     address:    a,
@@ -190,7 +188,7 @@ describe("SynapseBridge", function(this: Mocha.Suite) {
 
                         if (allowance.lte(infiniteCheckAmt)) {
                             const testPrivKey: string = process.env.TEST_PRIVKEY_A;
-                            const wallet = new Wallet(testPrivKey, newProviderForNetwork(ChainId.BSC));
+                            const wallet = new Wallet(testPrivKey, rpcProviderForNetwork(ChainId.BSC));
                             let txn: ContractTransaction = (await ERC20.approve({spender: bscZapAddr}, tokenParams, wallet)) as ContractTransaction;
                             await txn.wait(1);
 

--- a/test/entities/entities-test.ts
+++ b/test/entities/entities-test.ts
@@ -6,7 +6,7 @@ import {
 } from "../helpers";
 
 import {SynapseContracts} from "../../src/common/synapse_contracts";
-import {newProviderForNetwork} from "../../src/internal/rpcproviders";
+import {rpcProviderForNetwork} from "../../src/internal/rpcproviders";
 
 import type {SignerOrProvider} from "../../src/common/types";
 
@@ -24,7 +24,6 @@ import {
 import type {BaseContract} from "@ethersproject/contracts";
 
 describe("Entities tests", function(this: Mocha.Suite) {
-
     enum EntityKind {
         SynapseBridge = "SynapseBridge",
         L1BridgeZap   = "L1BridgeZap",
@@ -90,7 +89,7 @@ describe("Entities tests", function(this: Mocha.Suite) {
     for (const tc of testCases) {
         describe(Networks.networkName(tc.chainId), function(this: Mocha.Suite) {
             const
-                provider                = newProviderForNetwork(tc.chainId),
+                provider                = rpcProviderForNetwork(tc.chainId),
                 newInstanceArgs: fnArgs = {address: tc.address, chainId: tc.chainId, signerOrProvider: provider};
 
             let

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -8,7 +8,7 @@ import {Wallet} from "@ethersproject/wallet";
 import {BigNumber, BigNumberish} from "@ethersproject/bignumber";
 
 import type {Token} from "../../src";
-import {newProviderForNetwork} from "../../src/internal/rpcproviders";
+import {rpcProviderForNetwork} from "../../src/internal/rpcproviders";
 
 const TEN_BN: BigNumber = BigNumber.from(10);
 
@@ -36,7 +36,7 @@ export const
     makeWalletSignerWithProvider = (
         chainId: number,
         privKey: string
-    ): Wallet => new Wallet(privKey, newProviderForNetwork(chainId));
+    ): Wallet => new Wallet(privKey, rpcProviderForNetwork(chainId));
 
 
 export const

--- a/yarn.lock
+++ b/yarn.lock
@@ -2197,6 +2197,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2761,7 +2766,6 @@ ethereumjs-abi@0.6.8:
 
 "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
-  uid ee3994657fa7a427238e6ba92a84d0b529bbcde0
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0"
   dependencies:
     bn.js "^4.11.8"
@@ -3147,6 +3151,14 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.4.tgz#e8c6567f80ad7fc22fd302e7dcb72bafde9c1717"
+  integrity sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 fetch-ponyfill@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz#ae3ce5f732c645eab87e4ae8793414709b239893"
@@ -3265,6 +3277,13 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -5036,10 +5055,24 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.0.tgz#59390db4e489184fa35d4b74caf5510e8dfbaf3b"
+  integrity sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-fetch@~1.7.1:
   version "1.7.3"
@@ -6973,6 +7006,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
+  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
 
 web3-bzz@1.2.11:
   version "1.2.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,6 +620,18 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+"@web3-react/abstract-connector@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@web3-react/abstract-connector/-/abstract-connector-6.0.7.tgz#401b3c045f1e0fab04256311be49d5144e9badc6"
+  integrity sha512-RhQasA4Ox8CxUC0OENc1AJJm8UTybu/oOCM61Zjg6y0iF7Z0sqv1Ai1VdhC33hrQpA8qSBgoXN9PaP8jKmtdqg==
+  dependencies:
+    "@web3-react/types" "^6.0.7"
+
+"@web3-react/types@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@web3-react/types/-/types-6.0.7.tgz#34a6204224467eedc6123abaf55fbb6baeb2809f"
+  integrity sha512-ofGmfDhxmNT1/P/MgVa8IKSkCStFiyvXe+U5tyZurKdrtTDFU+wJ/LxClPDtFerWpczNFPUSrKcuhfPX1sI6+A==
+
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"


### PR DESCRIPTION
RpcConnector preloads JsonRpcProvider instances for all defined
networks, fixing an issue where RPC providers could possibly be
reinstantiated over multiple calls for newProviderForNetwork.

Deprecations:
	- internal/rpcproviders: newProviderForNetwork in favor of rpcProviderForNetwork