### PR TITLE
Release v0.93.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synapseprotocol/sdk",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "Synapse Protocol's NodeJS SDK",
   "repository": "github.com/synapsecns/sdk",
   "author": "synapsecns",

--- a/src/bridge/gasutils.ts
+++ b/src/bridge/gasutils.ts
@@ -6,7 +6,6 @@ import {parseUnits} from "@ethersproject/units";
 import {BigNumber}  from "@ethersproject/bignumber";
 
 import type {PopulatedTransaction} from "@ethersproject/contracts";
-import {rpcProviderForChain} from "@internal";
 
 export namespace GasUtils {
     type GasParams = {
@@ -64,21 +63,12 @@ export namespace GasUtils {
 
     export const makeGasParams = (chainId: number): GasParams => CHAIN_GAS_PARAMS[chainId] ?? {};
 
-    async function checkEIP1559(chainId: number): Promise<boolean> {
-        const provider = rpcProviderForChain(chainId);
-        const {maxFeePerGas} = await provider.getFeeData();
-
-        return maxFeePerGas !== null && typeof maxFeePerGas !== 'undefined'
-    }
-
-    export async function populateGasParams(
+    export const populateGasParams = (
         chainId:      number,
         txn:          PopulatedTransaction|Promise<PopulatedTransaction>,
         gasLimitKind: string
-    ): Promise<PopulatedTransaction> {
-        const supportsEIP1559 = await checkEIP1559(chainId);
-
-        return Promise.resolve(txn)
+    ): Promise<PopulatedTransaction> =>
+        Promise.resolve(txn)
             .then((tx: PopulatedTransaction): PopulatedTransaction => {
                 let {
                     maxFeePerGas,
@@ -90,15 +80,13 @@ export namespace GasUtils {
 
                 tx.chainId = chainId;
 
-                if (supportsEIP1559) {
-                    if (gasPrice) tx.maxFeePerGas = gasPrice;
-                    else if (maxFeePerGas) {
-                        tx.maxFeePerGas = maxFeePerGas;
-                        if (maxPriorityFee) tx.maxPriorityFeePerGas = maxPriorityFee;
+                if (gasPrice) {
+                    tx.gasPrice = gasPrice;
+                } else if (maxFeePerGas) {
+                    tx.maxFeePerGas = maxFeePerGas;
+                    if (maxPriorityFee) {
+                        tx.maxPriorityFeePerGas = maxPriorityFee;
                     }
-                } else {
-                    if (gasPrice) tx.gasPrice = gasPrice;
-                    else if (maxFeePerGas) tx.gasPrice = maxFeePerGas;
                 }
 
                 switch (gasLimitKind) {
@@ -112,5 +100,4 @@ export namespace GasUtils {
 
                 return tx
             })
-    }
 }

--- a/src/internal/minirpc.ts
+++ b/src/internal/minirpc.ts
@@ -128,12 +128,20 @@ export class MiniRpcProvider implements ExternalProvider {
     }
 
     private async _processBatch() {
-        const currentBatch = this._pendingBatch;
+        let currentBatch = this._pendingBatch;
 
         this._pendingBatch    = null;
         this._batchAggregator = null;
 
+        if (currentBatch === null) {
+            currentBatch = [];
+        }
+
         const requests: JsonRPCRequest[] = currentBatch.map(req => req.request);
+
+        if (requests.length === 0) {
+            return
+        }
 
         return fetchJson(this._url, JSON.stringify(requests))
             .then(result =>


### PR DESCRIPTION
This PR attempts to fix an issue reported wherein minirpc having a null batch during processing causes `batch.map()` to throw errors galore. 