### PR TITLE
SynapseBridge: executeBridgeTokenTransaction checks estimated bridge fee as part of validation

### DIFF
--- a/src/bridge/bridge.ts
+++ b/src/bridge/bridge.ts
@@ -276,9 +276,9 @@ export namespace Bridge {
                 });
 
                 let fixedAmountFrom: BigNumber = amountFrom;
-                const tokenInDecimals: number = tokenFrom.decimals(this.chainId);
-                if (tokenInDecimals !== 18) {
-                    fixedAmountFrom = fixWeiValue(amountFrom, tokenInDecimals);
+                const decimals: number = tokenFrom.decimals(chainIdTo);
+                if (decimals !== 18) {
+                    fixedAmountFrom = fixWeiValue(amountFrom, decimals);
                 }
 
                 validAmtFrom = bridgeFee.lt(fixedAmountFrom);

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -62,7 +62,22 @@ export const
     expectPromiseResolve = (
         data: Promise<any>,
         wantResolve: boolean
-    ): Chai.PromisedAssertion => wantResolve ? expectFulfilled(data) : expectRejected(data);
+    ): Chai.PromisedAssertion => wantResolve ? expectFulfilled(data) : expectRejected(data),
+    expectNothingFromPromise = async (data: Promise<any>): Promise<Chai.PromisedAssertion> => {
+        let promReturned: boolean = false;
+
+        if (!data) {
+            return expectToEventuallyBe(data).undefined
+        }
+
+        const promFn = (): void  => { promReturned = true; }
+
+        await Promise.resolve(data)
+            .then(promFn)
+            .catch(promFn);
+
+        return expect(promReturned).to.be.true
+    };
 
 export const
     expectBoolean   = (data: boolean, want:      boolean):             Chai.Assertion => expectToBe(data)[want ? "true" : "false"],

--- a/test/synapsebridge/ProviderInteractions-test.ts
+++ b/test/synapsebridge/ProviderInteractions-test.ts
@@ -68,7 +68,7 @@ async function buildWalletArgs(chainId: number, privkey: string=bridgeTestPrivke
     }
 }
 
-describe("SynapseBridge - Provider Interactions tests", async function(this: Mocha.Suite) {
+describe("SynapseBridge - Provider Interactions tests", function(this: Mocha.Suite) {
 
     interface TestOpts {
         executeSuccess: boolean,
@@ -149,7 +149,7 @@ describe("SynapseBridge - Provider Interactions tests", async function(this: Moc
                 tokenTo:     Tokens.USDC,
                 chainIdFrom: ChainId.AVALANCHE,
                 chainIdTo:   ChainId.ETH,
-                amountFrom:  Tokens.USDT.etherToWei("8.91", ChainId.AVALANCHE),
+                amountFrom:  BigNumber.from(8910000),
             },
             expected: {
                 executeSuccess: false,
@@ -157,6 +157,21 @@ describe("SynapseBridge - Provider Interactions tests", async function(this: Moc
                 bridgeFeeTc:    true
             },
             callStatic:         false,
+        },
+        {
+            args: {
+                tokenFrom:   Tokens.USDT,
+                tokenTo:     Tokens.USDC,
+                chainIdFrom: ChainId.AVALANCHE,
+                chainIdTo:   ChainId.ETH,
+                amountFrom:  BigNumber.from(8910000),
+            },
+            expected: {
+                executeSuccess: false,
+                canBridge:      false,
+                bridgeFeeTc:    true
+            },
+            callStatic:         true,
         },
         {
             args: {
@@ -317,6 +332,10 @@ describe("SynapseBridge - Provider Interactions tests", async function(this: Moc
                     ctx.timeout(5*1000);
 
                     let execProm = callStatic(prom);
+
+                    if (approval) {
+                        return (await expectNothingFromPromise(execProm))
+                    }
 
                     return (await (tc.expected.executeSuccess
                             ? expectFulfilled(execProm)

--- a/test/synapsebridge/ProviderInteractions-test.ts
+++ b/test/synapsebridge/ProviderInteractions-test.ts
@@ -145,6 +145,21 @@ describe("SynapseBridge - Provider Interactions tests", async function(this: Moc
         },
         {
             args: {
+                tokenFrom:   Tokens.USDT,
+                tokenTo:     Tokens.USDC,
+                chainIdFrom: ChainId.AVALANCHE,
+                chainIdTo:   ChainId.ETH,
+                amountFrom:  Tokens.USDT.etherToWei("8.91", ChainId.AVALANCHE),
+            },
+            expected: {
+                executeSuccess: false,
+                canBridge:      false,
+                bridgeFeeTc:    true
+            },
+            callStatic:         false,
+        },
+        {
+            args: {
                 tokenFrom:   Tokens.ETH,
                 tokenTo:     Tokens.NETH,
                 chainIdFrom: ChainId.ETH,


### PR DESCRIPTION
This would only apply to calls to `SynapseBridge.executeBridgeTokenTransaction()`, but those should be a large majority of actual transaction executions. 