### PR TITLE
Serialize object errors inside rejectPromise()

### DIFF
--- a/src/tokenswap.ts
+++ b/src/tokenswap.ts
@@ -125,7 +125,7 @@ export namespace TokenSwap {
     export async function calculateSwapRate(args: SwapParams): Promise<EstimatedSwapRate> {
         const {swapSupported: canSwap, reasonNotSupported} = swapSupported(args);
         if (!canSwap) {
-            return rejectPromise(reasonNotSupported)
+            return rejectPromise(reasonNotSupported.reason)
         }
 
         return resolveSwapData(args)

--- a/src/tokenswap.ts
+++ b/src/tokenswap.ts
@@ -139,7 +139,7 @@ export namespace TokenSwap {
     export async function buildSwapTokensTransaction(args: SwapTokensParams): Promise<PopulatedTransaction> {
         const {swapSupported: canSwap, reasonNotSupported} = swapSupported(args);
         if (!canSwap) {
-            return rejectPromise(reasonNotSupported)
+            return rejectPromise(reasonNotSupported.reason)
         }
 
         return resolveSwapData(args)


### PR DESCRIPTION
`calculateSwapRate` throws an error which is an object, which isn't passed correctly through the errors. The error shows up with empty fields. With the API using the SDK to determine errors, this needs to be fixed